### PR TITLE
Update GitHub Actions and add safe-chain installation

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
@@ -27,7 +27,7 @@ jobs:
           node-version: 22.x
 
       - name: Install safe-chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/1.4.7/download/install-safe-chain.sh | sh -s -- --ci
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh | sh -s -- --ci
 
       - name: Install Dependencies
         run: pnpm i

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -16,15 +16,18 @@ jobs:
     runs-on: ubuntu-latest-16-core
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22.x
+
+      - name: Install safe-chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/1.4.7/download/install-safe-chain.sh | sh -s -- --ci
 
       - name: Install Dependencies
         run: pnpm i


### PR DESCRIPTION
### Description

Pinned action to equivalent hash to versions and added installation step for safe-chain.

### Test Plan

This PR.

### Related Links

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CI step that downloads and executes an external install script (`curl | sh`), which can affect pipeline security and reliability. Action pinning reduces supply-chain risk but also changes the exact code executed by CI.
> 
> **Overview**
> **CI hardening and supply-chain scanning in `run-checks`.** The workflow now pins `actions/checkout`, `pnpm/action-setup`, and `actions/setup-node` to specific commit SHAs instead of floating version tags.
> 
> It also adds a new `Install safe-chain` step (via `curl`ing and executing the Safe-Chain installer) before dependency installation and checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 693eb66fb03916f7278a055f82efc6bc5fdbb6a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->