### PR TITLE
fix(web): run GraphQL generate before build in Turbo

### DIFF
--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -2,8 +2,17 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
+    "generate": {
+      "outputs": ["operations/generated/**"],
+      "env": [
+        "NEXT_PUBLIC_MULTISIG_INDEXER_MAINNET_API_KEY",
+        "NEXT_PUBLIC_MULTISIG_INDEXER_MAINNET_ENDPOINT",
+        "NEXT_PUBLIC_MULTISIG_INDEXER_TESTNET_API_KEY",
+        "NEXT_PUBLIC_MULTISIG_INDEXER_TESTNET_ENDPOINT"
+      ]
+    },
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "generate"],
       "outputs": [".next/**", "!.next/cache/**", "out/**"],
       "env": ["SENTRY_AUTH_TOKEN", "NEXT_RUNTIME"]
     },


### PR DESCRIPTION
The web package turbo.json overrode the root build task and dropped the generate dependency, so Next could build without operations/generated/sdk.ts and fail with module-not-found. Restore generate before build, declare operations/generated as generate outputs for correct caching, and list indexer env vars on generate so strict env mode passes them to codegen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-pipeline change that only adjusts Turbo task dependencies, caching outputs, and env passthrough; main risk is misconfigured env/output paths breaking codegen or cache behavior.
> 
> **Overview**
> Ensures the web app’s Turbo pipeline runs code generation before `build` by adding a local `generate` task and making `build` depend on it.
> 
> Declares `operations/generated/**` as `generate` outputs for correct caching and explicitly passes required `NEXT_PUBLIC_MULTISIG_INDEXER_*` env vars to codegen under strict env mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ca7cf275aaf8b378b965841df95e535a2b4bef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->