### PR TITLE
ci: restrict GITHUB_TOKEN permissions in run-checks workflow

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   NEXT_PUBLIC_APTOS_DEVNET_API_KEY: ${{ secrets.NEXT_PUBLIC_APTOS_DEVNET_API_KEY }}
   NEXT_PUBLIC_MULTISIG_INDEXER_MAINNET_API_KEY: ${{ secrets.NEXT_PUBLIC_MULTISIG_INDEXER_MAINNET_API_KEY }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an explicit workflow-level `permissions` block to `.github/workflows/run-checks.yaml` to enforce least privilege for `GITHUB_TOKEN`.

## Changes

- Added a `permissions` block immediately after the `on` block (before `env`):
  - `contents: read` — needed for checkout and repository read operations

This applies to all jobs in the workflow (including `run-all-checks`) unless overridden. No functional behavior changes; the workflow only performs checkout, dependency install, checks, and e2e tests, none of which require write scopes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96fbd8e2-33af-40d2-93da-f7217bed4ac3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96fbd8e2-33af-40d2-93da-f7217bed4ac3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

