### PR TITLE
fix: restrict explore iframe src to http(s) URLs to prevent XSS

### DIFF
--- a/apps/web/app/(authenticated)/vault/[vaultId]/explore/(embedded)/search/page.tsx
+++ b/apps/web/app/(authenticated)/vault/[vaultId]/explore/(embedded)/search/page.tsx
@@ -48,10 +48,12 @@ export default function VaultExploreSearchPage() {
   const handleUrlSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (inputUrl.trim()) {
-      const formattedUrl = inputUrl.startsWith('http')
-        ? inputUrl
-        : `https://${inputUrl}`;
+    const trimmedUrl = inputUrl.trim();
+
+    if (trimmedUrl) {
+      const formattedUrl = trimmedUrl.startsWith('http')
+        ? trimmedUrl
+        : `https://${trimmedUrl}`;
 
       try {
         const parsedUrl = new URL(formattedUrl);

--- a/apps/web/app/(authenticated)/vault/[vaultId]/explore/(embedded)/search/page.tsx
+++ b/apps/web/app/(authenticated)/vault/[vaultId]/explore/(embedded)/search/page.tsx
@@ -53,8 +53,6 @@ export default function VaultExploreSearchPage() {
         ? inputUrl
         : `https://${inputUrl}`;
 
-      if (formattedUrl === url) return;
-
       try {
         const parsedUrl = new URL(formattedUrl);
 
@@ -68,6 +66,11 @@ export default function VaultExploreSearchPage() {
           );
           return;
         }
+
+        // Compare against the normalized href so resubmitting the same
+        // input (which `new URL` may canonicalize, e.g. by adding a
+        // trailing slash) does not trigger a redundant reload.
+        if (parsedUrl.href === url) return;
 
         setUrl(parsedUrl.href);
         setIsIframeLoading(true);

--- a/apps/web/app/(authenticated)/vault/[vaultId]/explore/(embedded)/search/page.tsx
+++ b/apps/web/app/(authenticated)/vault/[vaultId]/explore/(embedded)/search/page.tsx
@@ -56,8 +56,20 @@ export default function VaultExploreSearchPage() {
       if (formattedUrl === url) return;
 
       try {
-        new URL(formattedUrl);
-        setUrl(formattedUrl);
+        const parsedUrl = new URL(formattedUrl);
+
+        // Only allow http(s) URLs to reach the iframe. This prevents
+        // dangerous schemes (e.g. javascript:, data:) from being loaded
+        // and executed inside the sandboxed frame.
+        if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+          console.warn(
+            'Unsupported URL protocol provided:',
+            parsedUrl.protocol
+          );
+          return;
+        }
+
+        setUrl(parsedUrl.href);
         setIsIframeLoading(true);
       } catch (error) {
         console.warn('Invalid URL provided:', error);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

CodeQL flagged the embedded explore search iframe (`apps/web/app/(authenticated)/vault/[vaultId]/explore/(embedded)/search/page.tsx`) with the `js/xss-through-dom` query: *"DOM text reinterpreted as HTML / DOM text is reinterpreted as HTML without escaping meta-characters."*

User-supplied input from the URL `Input` field flowed into the sandboxed iframe `src` after only being parsed with `new URL(...)`, without validating the URL scheme. Because the iframe is sandboxed with `allow-scripts allow-same-origin`, a dangerous scheme such as `javascript:` or `data:` could be loaded and executed.

This change adds a protocol allowlist in `handleUrlSubmit`: after parsing, the URL is only accepted (and assigned to state / the iframe `src`) when its protocol is `http:` or `https:`. The sanitized `parsedUrl.href` is stored, breaking the tainted data flow into the sink.

### Test Plan

- `oxlint --deny-warnings` passes on the modified file.
- `prettier --check` passes on the modified file (formatted).
- Manual: entering a normal URL (e.g. `example.com` or `https://example.com`) still loads the iframe as before; entering a `javascript:`/`data:` scheme is rejected and does not reach the iframe `src`.

### Related Links

CodeQL alert: `js/xss-through-dom` (DOM text reinterpreted as HTML) on the explore search page iframe `src`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af38ad6b-6636-4525-a2ad-d79090ee019d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af38ad6b-6636-4525-a2ad-d79090ee019d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

