### PR TITLE
Pin GitHub Actions to latest releases older than 3 days

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest-16-core
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.x
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Updates `.github/workflows/run-checks.yaml` to pin all third-party GitHub Actions to full commit SHAs with version comments. Each action is bumped to the latest release that was published more than 3 days ago (as of 2026-07-02):

| Action | Previous | Updated |
|--------|----------|---------|
| `actions/checkout` | v4.3.0 | v7.0.0 (`9c091bb`) |
| `pnpm/action-setup` | v4.x | v6.0.9 (`0ebf471`) |
| `actions/setup-node` | v4.x | v6.4.0 (`48b55a0`) |

### Test Plan

- CI workflow will run on this PR and validate the updated action pins.

### Related Links

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8635928-992d-451a-986e-1379c967e71a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8635928-992d-451a-986e-1379c967e71a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

